### PR TITLE
Disabling OCW edition flavour (theme)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN git clone https://github.com/glitch-soc/mastodon.git /mastodon
 RUN git clone --branch "main" https://github.com/ronilaukkarinen/mastodon-bird-ui.git /tmp/mastodon-bird-ui
 
 COPY --chown=mastodon:mastodon ./patches/mastodon-bird-ui/ /tmp/mastodon-bird-ui-patches/
-COPY --chown=mastodon:mastodon ./patches/glitch-soc/ /tmp/glitch-soc-patches/
+#COPY --chown=mastodon:mastodon ./patches/glitch-soc/ /tmp/glitch-soc-patches/
 
 WORKDIR /tmp/mastodon-bird-ui
 
@@ -111,13 +111,13 @@ RUN mkdir /mastodon/app/javascript/styles/elephant ; \
     rm -rf /tmp/mastodon-bird-ui ; \
     rm -rf /tmp/mastodon-bird-ui-patches
 
-RUN git config user.name "ContainerBuild" ; \
-    git config user.email "build@localhost" ; \
-    git am /tmp/glitch-soc-patches/0001-Add-OCW-edition-flavour-files.patch ; \
-    git am /tmp/glitch-soc-patches/0002-Attempting-to-fix-flavour.patch ; \
-    git am /tmp/glitch-soc-patches/0003-Fix-regression-with-sign-in-state.patch ; \
-    git am /tmp/glitch-soc-patches/0004-Fix-for-recent-changes-2024-01-16.patch ; \
-    rm -rf /tmp/glitch-soc-patches
+#RUN git config user.name "ContainerBuild" ; \
+#    git config user.email "build@localhost" ; \
+#    git am /tmp/glitch-soc-patches/0001-Add-OCW-edition-flavour-files.patch ; \
+#    git am /tmp/glitch-soc-patches/0002-Attempting-to-fix-flavour.patch ; \
+#    git am /tmp/glitch-soc-patches/0003-Fix-regression-with-sign-in-state.patch ; \
+#    git am /tmp/glitch-soc-patches/0004-Fix-for-recent-changes-2024-01-16.patch ; \
+#    rm -rf /tmp/glitch-soc-patches
 
 # Copy Bird UI theme files to /mastodon/app/javascript/styles.
 COPY ./themes/styles/elephant.scss /mastodon/app/javascript/styles/elephant.scss


### PR DESCRIPTION
I'm disabling the OCW edition flavour from being added to the container image for the time being. Upstream Mastodon are making a lot of changes to components and keeping up with it isn't easy. ☹️ 

In order to fix this, I'm going to need to look into a better way of handling the dev and build steps for the flavour. If me removing the flavour temporarily breaks functionality for those who have it set as their default, including myself, I will revert back to the last good container image until I can get everything sorted out.