### PR TITLE
Add libvips and ffmpeg compilation to core image

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -47,33 +47,57 @@ RUN echo "Etc/UTC" > /etc/localtime && \
     mkdir -p /etc/apt/keyrings && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        ffmpeg \
+        curl \
         file \
-        imagemagick \
         libjemalloc2 \
         patchelf \
         procps \
         tini \
         tzdata \
         wget \
-        g++ \
-        gcc \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
         git \
         libgdbm-dev \
+        libglib2.0-dev \
         libgmp-dev \
         libicu-dev \
         libidn-dev \
         libpq-dev \
         libssl-dev \
-        make \
+        libtool \
+        meson \
+        nasm \
+        pkg-config \
         shared-mime-info \
-        zlib1g-dev \
-        libssl3 \
-        libpq5 \
-        libicu72 \
-        libidn12 \
-        libreadline8 \
-        libyaml-0-2 && \
+        xz-utils \
+    # ImageMagick components (Temporary as a fallback)
+        imagemagick \
+    # libvips components
+        libcgif-dev \
+        libexif-dev \
+        libexpat1-dev \
+        libgirepository1.0-dev \
+        libheif-dev \
+        libimagequant-dev \
+        libjpeg62-turbo-dev \
+        liblcms2-dev \
+        liborc-dev \
+        libspng-dev \
+        libtiff-dev \
+        libwebp-dev \
+    # ffmpeg components
+        libdav1d-dev \
+        liblzma-dev \
+        libmp3lame-dev \
+        libopus-dev \
+        libsnappy-dev \
+        libvorbis-dev \
+        libvpx-dev \
+        libx264-dev \
+        libx265-dev && \
     patchelf --add-needed libjemalloc.so.2 /usr/local/bin/ruby && \
     apt-get purge -y patchelf && \
     apt-get autoremove -y && \
@@ -87,6 +111,7 @@ COPY --from=node /usr/local/lib /usr/local/lib
 
 WORKDIR /opt/mastodon
 
+# Apply custom patches
 RUN rm .profile && \
     git config --global --add safe.directory /opt/mastodon && \
     git config --global init.defaultBranch main && \
@@ -104,6 +129,69 @@ RUN git config user.name "ContainerBuild" ; \
 RUN rm /usr/local/bin/yarn* ; \
     corepack enable && \
     corepack prepare --activate
+
+# Build libvips
+FROM --platform=${TARGETPLATFORM} build as libvips-build
+
+ARG VIPS_VERSION=8.15.3
+ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
+
+WORKDIR /usr/local/libvips/src
+
+ADD ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz /usr/local/libvips/src/
+RUN tar xf vips-${VIPS_VERSION}.tar.xz
+
+WORKDIR /usr/local/libvips/src/vips-${VIPS_VERSION}
+
+RUN meson setup build \
+        --prefix /usr/local/libvips \
+        --libdir=lib \
+        -Ddeprecated=false \
+        -Dintrospection=disabled \
+        -Dmodules=disabled \
+        -Dexamples=false; \
+    cd build; \
+    ninja; \
+    ninja install
+
+# Build ffmpeg
+FROM --platform=${TARGETPLATFORM} build as ffmpeg-build
+
+ARG FFMPEG_VERSION=7.0.2
+ARG FFMPEG_URL=https://ffmpeg.org/releases
+
+WORKDIR /usr/local/ffmpeg/src
+
+ADD ${FFMPEG_URL}/ffmpeg-${FFMPEG_VERSION}.tar.xz /usr/local/ffmpeg/src/
+RUN tar xf ffmpeg-${FFMPEG_VERSION}.tar.xz
+
+WORKDIR /usr/local/ffmpeg/src/ffmpeg-${FFMPEG_VERSION}
+
+RUN ./configure \
+        --prefix=/usr/local/ffmpeg \
+        --toolchain=hardened \
+        --disable-debug \
+        --disable-devices \
+        --disable-doc \
+        --disable-ffplay \
+        --disable-network \
+        --disable-static \
+        --enable-ffmpeg \
+        --enable-ffprobe \
+        --enable-gpl \
+        --enable-libdav1d \
+        --enable-libmp3lame \
+        --enable-libopus \
+        --enable-libsnappy \
+        --enable-libvorbis \
+        --enable-libvpx \
+        --enable-libwebp \
+        --enable-libx264 \
+        --enable-libx265 \
+        --enable-shared \
+        --enable-version3; \
+    make -j$(nproc); \
+    make install
 
 FROM --platform=${TARGETPLATFORM} build as bundler
 
@@ -126,12 +214,11 @@ FROM --platform=${TARGETPLATFORM} build as precompiler
 COPY --from=yarn /opt/mastodon /opt/mastodon/
 COPY --from=bundler /opt/mastodon /opt/mastodon/
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
+COPY --from=libvips-build /usr/local/libvips/bin /usr/local/bin
+COPY --from=libvips-build /usr/local/libvips/lib /usr/local/lib
 
-RUN ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=precompile_placeholder \
-    ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=precompile_placeholder \
-    ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=precompile_placeholder \
-    OTP_SECRET=precompile_placeholder \
-    SECRET_KEY_BASE=precompile_placeholder \
+RUN ldconfig; \
+    SECRET_KEY_BASE_DUMMY=1 \
     bundle exec rails assets:precompile && \
     rm -rf /opt/mastodon/tmp
 
@@ -156,8 +243,13 @@ WORKDIR /opt/mastodon
 COPY --from=precompiler /opt/mastodon/public/packs /opt/mastodon/public/packs
 COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
+COPY --from=libvips-build /usr/local/libvips/bin /usr/local/bin
+COPY --from=libvips-build /usr/local/libvips/lib /usr/local/lib
+COPY --from=ffmpeg-build /usr/local/ffmpeg/bin /usr/local/bin
+COPY --from=ffmpeg-build /usr/local/ffmpeg/lib /usr/local/lib
 
-RUN bundle exec bootsnap precompile --gemfile app/ lib/
+RUN ldconfig; \
+    bundle exec bootsnap precompile --gemfile app/ lib/
 
 USER mastodon
 EXPOSE 3000


### PR DESCRIPTION
## Description

Following in line with how Mastodon upstream is building their container images with this. This adds `libvips` and `ffmpeg` compilation steps to the core Mastodon image build.

Changes were sourced from [the current `Dockerfile` for Mastodon](https://github.com/mastodon/mastodon/blob/3e91c101b3c4b5166dab778837e38bed424b4333/Dockerfile) (As of this PR).

The major difference from upstream is keeping `imagemagick` as a temporary fallback. Once I can confirm that `libvips` works properly for us, I will remove `imagemagick` from being included in the container image.

### Related issues

- None
