### PR TITLE
Remove ImageMagick from build

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -73,8 +73,6 @@ RUN echo "Etc/UTC" > /etc/localtime && \
         pkg-config \
         shared-mime-info \
         xz-utils \
-    # ImageMagick components (Temporary as a fallback)
-        imagemagick \
     # libvips components
         libcgif-dev \
         libexif-dev \


### PR DESCRIPTION
## Description

Removing `imagemagick` from being installed during the container build process. `libvips` has been in use for the last week and I have not noticed any issues from it being used over `imagemagick`.

### Related issues

- None
