### PR TITLE
Bump Ruby to v3.3.5

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -2,7 +2,7 @@ ARG TARGETPLATFORM=${TARGETPLATFORM}
 ARG BUILDPLATFORM=${BUILDPLATFORM}
 
 # Ruby image to use for base image.
-ARG RUBY_VERSION="3.3.2"
+ARG RUBY_VERSION="3.3.5"
 # # Node version to use in base image.
 ARG NODE_MAJOR="20"
 # Debian image to use for base image.


### PR DESCRIPTION
## Description

Updates Ruby to `v3.3.5`.

### Related issues

- None
