### PR TITLE
Bump NodeJS to v22

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -4,7 +4,7 @@ ARG BUILDPLATFORM=${BUILDPLATFORM}
 # Ruby image to use for base image.
 ARG RUBY_VERSION="3.3.2"
 # # Node version to use in base image.
-ARG NODE_MAJOR="20"
+ARG NODE_MAJOR="22"
 # Debian image to use for base image.
 ARG DEBIAN_VERSION="bookworm"
 

--- a/Dockerfile.streaming
+++ b/Dockerfile.streaming
@@ -2,7 +2,7 @@ ARG TARGETPLATFORM=${TARGETPLATFORM}
 ARG BUILDPLATFORM=${BUILDPLATFORM}
 
 # Node version to use in base image.
-ARG NODE_MAJOR="20"
+ARG NODE_MAJOR="22"
 # Debian image to use for base image.
 ARG DEBIAN_VERSION="bookworm"
 


### PR DESCRIPTION
## Description

Bumps the NodeJS version to `v22`.

### Related issues

- None
