### PR TITLE
Bump NodeJS to v22

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -73,8 +73,6 @@ RUN echo "Etc/UTC" > /etc/localtime && \
         pkg-config \
         shared-mime-info \
         xz-utils \
-    # ImageMagick components (Temporary as a fallback)
-        imagemagick \
     # libvips components
         libcgif-dev \
         libexif-dev \

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -124,6 +124,12 @@ RUN git config user.name "ContainerBuild" ; \
     git am /tmp/fix-ios-pwa.patch; \
     rm /tmp/fix-ios-pwa.patch
 
+# Add Tangerine UI theme
+RUN git clone https://github.com/nileane/TangerineUI-for-Mastodon.git /tmp/tangerine-ui && \
+    cp -r /tmp/tangerine-ui/mastodon/app/javascript/styles/* /opt/mastodon/app/javascript/styles && \
+    cp -r /tmp/tangerine-ui/mastodon/app/javascript/skins/vanilla/* /opt/mastodon/app/javascript/skins/vanilla && \
+    rm -rf /tmp/tangerine-ui
+
 RUN rm /usr/local/bin/yarn* ; \
     corepack enable && \
     corepack prepare --activate

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -244,6 +244,8 @@ RUN rm .profile && \
 
 WORKDIR /opt/mastodon
 
+COPY --from=build /opt/mastodon/app/javascript/styles /opt/mastodon/app/javascript/styles
+COPY --from=build /opt/mastodon/app/javascript/skins/vanilla /opt/mastodon/app/javascript/skins/vanilla
 COPY --from=precompiler /opt/mastodon/public/packs /opt/mastodon/public/packs
 COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -8,8 +8,8 @@ ARG NODE_MAJOR="20"
 # Debian image to use for base image.
 ARG DEBIAN_VERSION="bookworm"
 
-FROM --platform=${TARGETPLATFORM} docker.io/node:${NODE_MAJOR}-${DEBIAN_VERSION}-slim as node
-FROM --platform=${TARGETPLATFORM} docker.io/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} as ruby
+FROM --platform=${TARGETPLATFORM} docker.io/node:${NODE_MAJOR}-${DEBIAN_VERSION}-slim AS node
+FROM --platform=${TARGETPLATFORM} docker.io/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS ruby
 
 ARG RAILS_SERVE_STATIC_FILES="true"
 ARG RUBY_YJIT_ENABLE="1"
@@ -104,7 +104,7 @@ RUN echo "Etc/UTC" > /etc/localtime && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-FROM --platform=${TARGETPLATFORM} ruby as build
+FROM --platform=${TARGETPLATFORM} ruby AS build
 
 COPY --from=node /usr/local/bin /usr/local/bin
 COPY --from=node /usr/local/lib /usr/local/lib
@@ -131,7 +131,7 @@ RUN rm /usr/local/bin/yarn* ; \
     corepack prepare --activate
 
 # Build libvips
-FROM --platform=${TARGETPLATFORM} build as libvips-build
+FROM --platform=${TARGETPLATFORM} build AS libvips-build
 
 ARG VIPS_VERSION=8.15.3
 ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
@@ -155,7 +155,7 @@ RUN meson setup build \
     ninja install
 
 # Build ffmpeg
-FROM --platform=${TARGETPLATFORM} build as ffmpeg-build
+FROM --platform=${TARGETPLATFORM} build AS ffmpeg-build
 
 ARG FFMPEG_VERSION=7.0.2
 ARG FFMPEG_URL=https://ffmpeg.org/releases
@@ -193,7 +193,7 @@ RUN ./configure \
     make -j$(nproc); \
     make install
 
-FROM --platform=${TARGETPLATFORM} build as bundler
+FROM --platform=${TARGETPLATFORM} build AS bundler
 
 WORKDIR /opt/mastodon
 
@@ -203,13 +203,13 @@ RUN bundle config set --global frozen "true" && \
     bundle config set silence_root_warning "true" && \
     bundle install -j"$(nproc)"
 
-FROM --platform=${TARGETPLATFORM} build as yarn
+FROM --platform=${TARGETPLATFORM} build AS yarn
 
 WORKDIR /opt/mastodon
 
 RUN yarn workspaces focus --production @mastodon/mastodon
 
-FROM --platform=${TARGETPLATFORM} build as precompiler
+FROM --platform=${TARGETPLATFORM} build AS precompiler
 
 COPY --from=yarn /opt/mastodon /opt/mastodon/
 COPY --from=bundler /opt/mastodon /opt/mastodon/
@@ -222,7 +222,7 @@ RUN ldconfig; \
     bundle exec rails assets:precompile && \
     rm -rf /opt/mastodon/tmp
 
-FROM --platform=${TARGETPLATFORM} ruby as mastodon
+FROM --platform=${TARGETPLATFORM} ruby AS mastodon
 
 WORKDIR /opt/mastodon
 

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -4,7 +4,7 @@ ARG BUILDPLATFORM=${BUILDPLATFORM}
 # Ruby image to use for base image.
 ARG RUBY_VERSION="3.3.2"
 # # Node version to use in base image.
-ARG NODE_MAJOR="20"
+ARG NODE_MAJOR="22"
 # Debian image to use for base image.
 ARG DEBIAN_VERSION="bookworm"
 

--- a/Dockerfile.streaming
+++ b/Dockerfile.streaming
@@ -2,7 +2,7 @@ ARG TARGETPLATFORM=${TARGETPLATFORM}
 ARG BUILDPLATFORM=${BUILDPLATFORM}
 
 # Node version to use in base image.
-ARG NODE_MAJOR="20"
+ARG NODE_MAJOR="22"
 # Debian image to use for base image.
 ARG DEBIAN_VERSION="bookworm"
 

--- a/Dockerfile.streaming
+++ b/Dockerfile.streaming
@@ -6,7 +6,7 @@ ARG NODE_MAJOR="20"
 # Debian image to use for base image.
 ARG DEBIAN_VERSION="bookworm"
 
-FROM --platform=${TARGETPLATFORM} docker.io/node:${NODE_MAJOR}-${DEBIAN_VERSION}-slim as streaming
+FROM --platform=${TARGETPLATFORM} docker.io/node:${NODE_MAJOR}-${DEBIAN_VERSION}-slim AS streaming
 
 ARG UID="991"
 ARG GID="991"


### PR DESCRIPTION
## Description

Bumps NodeJS to `v22`.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#27 :point\_left:
    - \#28
      - \#29
